### PR TITLE
Fixed typo in documentation

### DIFF
--- a/docs/js/AppViewModel.js
+++ b/docs/js/AppViewModel.js
@@ -15,7 +15,7 @@ function AppViewModel(contentDivId, drawer) {
 
     self.documentationItems = [
         new DocumentationItem('appbar', 'App bar', 'https://raw.githubusercontent.com/spiegelp/MaterialDesignExtensions/master/screenshots/AppBar1.png', 'snippets/documentation/appbar.html'),
-        new DocumentationItem('autocomplete', 'Autocomplate', 'https://raw.githubusercontent.com/spiegelp/MaterialDesignExtensions/master/screenshots/Autocomplete.png', 'snippets/documentation/autocomplete.html'),
+        new DocumentationItem('autocomplete', 'Autocomplete', 'https://raw.githubusercontent.com/spiegelp/MaterialDesignExtensions/master/screenshots/Autocomplete.png', 'snippets/documentation/autocomplete.html'),
         new DocumentationItem('filesystemcontrols', 'File system controls', 'https://raw.githubusercontent.com/spiegelp/MaterialDesignExtensions/master/screenshots/OpenFileControl1.png', 'snippets/documentation/filesystemcontrols.html'),
         new DocumentationItem('gridlist', 'Grid list', 'https://raw.githubusercontent.com/spiegelp/MaterialDesignExtensions/master/screenshots/GridList.png', 'snippets/documentation/gridlist.html'),
         new DocumentationItem('navigation', 'Navigation', 'https://raw.githubusercontent.com/spiegelp/MaterialDesignExtensions/master/screenshots/SideNavigation.png', 'snippets/documentation/navigation.html'),


### PR DESCRIPTION
"Autocomplete" was misspelled "Autocomplate" in the documentation overview. This fixes this.