### PR TITLE
Added a "dense" style to PersistentSearch

### DIFF
--- a/MaterialDesignExtensions/Themes/SearchTemplates.xaml
+++ b/MaterialDesignExtensions/Themes/SearchTemplates.xaml
@@ -1,30 +1,45 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:wpfLib="http://materialdesigninxaml.net/winfx/xaml/themes"
-                    xmlns:convertersLib="clr-namespace:MaterialDesignThemes.Wpf.Converters;assembly=MaterialDesignThemes.Wpf"
-                    xmlns:controls="clr-namespace:MaterialDesignExtensions.Controls"
-                    xmlns:converters="clr-namespace:MaterialDesignExtensions.Converters"
-                    xmlns:internalCommands="clr-namespace:MaterialDesignExtensions.Commands.Internal">
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="clr-namespace:MaterialDesignExtensions.Controls"
+    xmlns:converters="clr-namespace:MaterialDesignExtensions.Converters"
+    xmlns:convertersLib="clr-namespace:MaterialDesignThemes.Wpf.Converters;assembly=MaterialDesignThemes.Wpf"
+    xmlns:internalCommands="clr-namespace:MaterialDesignExtensions.Commands.Internal"
+    xmlns:wpfLib="http://materialdesigninxaml.net/winfx/xaml/themes">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Shadows.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Button.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBox.xaml" />
         <ResourceDictionary>
-            <convertersLib:BrushRoundConverter x:Key="brushRoundConverter"/>
+            <convertersLib:BrushRoundConverter x:Key="brushRoundConverter" />
         </ResourceDictionary>
     </ResourceDictionary.MergedDictionaries>
-    
-    <converters:BooleanOrToVisibilityConverter x:Key="orTrueAsVisibleConverter" TrueValue="Visible" FalseValue="Hidden" />
-    <converters:BooleanAndToVisibilityConverter x:Key="andTrueAsVisibleConverter" TrueValue="Visible" FalseValue="Hidden" />
-    <converters:BooleanOrToVisibilityConverter x:Key="orFalseAsVisibleConverter" TrueValue="Hidden" FalseValue="Visible" />
+
+    <converters:BooleanOrToVisibilityConverter
+        x:Key="orTrueAsVisibleConverter"
+        FalseValue="Hidden"
+        TrueValue="Visible" />
+    <converters:BooleanAndToVisibilityConverter
+        x:Key="andTrueAsVisibleConverter"
+        FalseValue="Hidden"
+        TrueValue="Visible" />
+    <converters:BooleanOrToVisibilityConverter
+        x:Key="orFalseAsVisibleConverter"
+        FalseValue="Visible"
+        TrueValue="Hidden" />
     <converters:NotNullBooleanConverter x:Key="notNullBooleanConverter" />
     <converters:EmptyEnumerableToBoolConverter x:Key="emptyEnumerableToFalseConverter" EmptyValue="False" />
-    <converters:BoolToVisibilityConverter x:Key="falseToHiddenConverter" TrueValue="Visible" FalseValue="Hidden" />
+    <converters:BoolToVisibilityConverter
+        x:Key="falseToHiddenConverter"
+        FalseValue="Hidden"
+        TrueValue="Visible" />
     <converters:BooleanOrConverter x:Key="booleanOrConverter" />
 
-    <Style TargetType="{x:Type controls:PersistentSearch}">
+    <Style x:Key="MaterialDesignPersistentSearch" TargetType="{x:Type controls:PersistentSearch}">
         <Setter Property="Background" Value="{DynamicResource MaterialDesignBackground}" />
+        <Setter Property="FontSize" Value="20" />
+        <Setter Property="Padding" Value="16,8,8,8" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="wpfLib:ShadowAssist.ShadowDepth" Value="Depth1" />
@@ -32,9 +47,11 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type controls:PersistentSearch}">
                     <Grid HorizontalAlignment="{TemplateBinding HorizontalAlignment}" VerticalAlignment="{TemplateBinding VerticalAlignment}">
-                        <Border Background="{TemplateBinding Background}"
-                                Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpfLib:ShadowAssist.ShadowDepth), Converter={x:Static convertersLib:ShadowConverter.Instance}}"
-                                HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                        <Border
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Stretch"
+                            Background="{TemplateBinding Background}"
+                            Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpfLib:ShadowAssist.ShadowDepth), Converter={x:Static convertersLib:ShadowConverter.Instance}}">
                             <Border.Style>
                                 <Style TargetType="Border">
                                     <Style.Triggers>
@@ -48,57 +65,102 @@
                                 </Style>
                             </Border.Style>
                         </Border>
-                        <Border x:Name="rootBorder" Background="Transparent"
-                                HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                        <Border
+                            x:Name="rootBorder"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Stretch"
+                            Background="Transparent">
                             <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto" />
                                     <ColumnDefinition Width="100*" />
                                     <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>
-                                <ContentControl Content="{TemplateBinding SearchIcon}" Width="24" Height="24" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                <ContentControl
+                                    Width="24"
+                                    Height="24"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Content="{TemplateBinding SearchIcon}">
                                     <ContentControl.Resources>
                                         <DataTemplate DataType="{x:Type wpfLib:PackIconKind}">
-                                            <wpfLib:PackIcon Kind="{Binding}" Width="24" Height="24" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                            <wpfLib:PackIcon
+                                                Width="24"
+                                                Height="24"
+                                                HorizontalAlignment="Center"
+                                                VerticalAlignment="Center"
+                                                Kind="{Binding}" />
                                         </DataTemplate>
                                     </ContentControl.Resources>
                                     <ContentControl.Visibility>
                                         <MultiBinding Converter="{StaticResource orFalseAsVisibleConverter}">
-                                            <Binding Path="IsFocused" ElementName="searchTextBox" />
-                                            <Binding Path="SearchTerm" RelativeSource="{RelativeSource TemplatedParent}" Converter="{StaticResource notNullBooleanConverter}" />
+                                            <Binding ElementName="searchTextBox" Path="IsFocused" />
+                                            <Binding
+                                                Converter="{StaticResource notNullBooleanConverter}"
+                                                Path="SearchTerm"
+                                                RelativeSource="{RelativeSource TemplatedParent}" />
                                         </MultiBinding>
                                     </ContentControl.Visibility>
                                 </ContentControl>
-                                <Button x:Name="cancelButton" Style="{DynamicResource MaterialDesignToolForegroundButton}"
-                                        Margin="8,0,8,0" VerticalAlignment="Center">
+                                <Button
+                                    x:Name="cancelButton"
+                                    Margin="8,0,8,0"
+                                    VerticalAlignment="Center"
+                                    Style="{DynamicResource MaterialDesignToolForegroundButton}">
                                     <Button.Visibility>
                                         <MultiBinding Converter="{StaticResource orTrueAsVisibleConverter}">
-                                            <Binding Path="IsFocused" ElementName="searchTextBox" />
-                                            <Binding Path="SearchTerm" RelativeSource="{RelativeSource TemplatedParent}" Converter="{StaticResource notNullBooleanConverter}" />
+                                            <Binding ElementName="searchTextBox" Path="IsFocused" />
+                                            <Binding
+                                                Converter="{StaticResource notNullBooleanConverter}"
+                                                Path="SearchTerm"
+                                                RelativeSource="{RelativeSource TemplatedParent}" />
                                         </MultiBinding>
                                     </Button.Visibility>
-                                    <wpfLib:PackIcon Kind="ArrowLeft" Width="24" Height="24" />
+                                    <wpfLib:PackIcon
+                                        Width="24"
+                                        Height="24"
+                                        Kind="ArrowLeft" />
                                 </Button>
-                                <TextBox x:Name="searchTextBox" Grid.Column="1" wpfLib:HintAssist.Hint="{TemplateBinding SearchHint}"
-                                         Text="{Binding Path=SearchTerm, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, RelativeSource={RelativeSource TemplatedParent}}"
-                                         FontSize="20" BorderBrush="Transparent"
-                                         Margin="16,8,8,8" HorizontalAlignment="Stretch" VerticalAlignment="Center" />
-                                <Button x:Name="clearButton" Grid.Column="2" Style="{DynamicResource MaterialDesignToolForegroundButton}"
-                                        Margin="8,0,8,0" VerticalAlignment="Center">
+                                <TextBox
+                                    x:Name="searchTextBox"
+                                    Grid.Column="1"
+                                    Margin="{TemplateBinding Padding}"
+                                    HorizontalAlignment="Stretch"
+                                    VerticalAlignment="Center"
+                                    wpfLib:HintAssist.Hint="{TemplateBinding SearchHint}"
+                                    BorderBrush="Transparent"
+                                    FontSize="{TemplateBinding FontSize}"
+                                    Text="{Binding Path=SearchTerm, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, RelativeSource={RelativeSource TemplatedParent}}" />
+                                <Button
+                                    x:Name="clearButton"
+                                    Grid.Column="2"
+                                    Margin="8,0,8,0"
+                                    VerticalAlignment="Center"
+                                    Style="{DynamicResource MaterialDesignToolForegroundButton}">
                                     <Button.Visibility>
                                         <MultiBinding Converter="{StaticResource andTrueAsVisibleConverter}">
-                                            <Binding Path="IsMouseOver" ElementName="rootBorder" />
-                                            <Binding Path="SearchTerm" RelativeSource="{RelativeSource TemplatedParent}" Converter="{StaticResource notNullBooleanConverter}" />
+                                            <Binding ElementName="rootBorder" Path="IsMouseOver" />
+                                            <Binding
+                                                Converter="{StaticResource notNullBooleanConverter}"
+                                                Path="SearchTerm"
+                                                RelativeSource="{RelativeSource TemplatedParent}" />
                                         </MultiBinding>
                                     </Button.Visibility>
-                                    <wpfLib:PackIcon Kind="Close" Width="24" Height="24" />
+                                    <wpfLib:PackIcon
+                                        Width="24"
+                                        Height="24"
+                                        Kind="Close" />
                                 </Button>
-                                <controls:AutocompletePopup x:Name="searchSuggestionsPopup"
-                                       PlacementTarget="{Binding ElementName=rootBorder}"
-                                       Placement="Bottom"
-                                       PopupAnimation="Fade" AllowsTransparency="True" Focusable="False"
-                                       SnapsToDevicePixels="True"
-                                       MaxHeight="300" Width="{Binding Path=ActualWidth, ElementName=rootBorder}">
+                                <controls:AutocompletePopup
+                                    x:Name="searchSuggestionsPopup"
+                                    Width="{Binding Path=ActualWidth, ElementName=rootBorder}"
+                                    MaxHeight="300"
+                                    AllowsTransparency="True"
+                                    Focusable="False"
+                                    Placement="Bottom"
+                                    PlacementTarget="{Binding ElementName=rootBorder}"
+                                    PopupAnimation="Fade"
+                                    SnapsToDevicePixels="True">
                                     <controls:AutocompletePopup.Style>
                                         <Style TargetType="{x:Type Popup}">
                                             <Style.Triggers>
@@ -113,17 +175,25 @@
                                         </Style>
                                     </controls:AutocompletePopup.Style>
                                     <Border HorizontalAlignment="Stretch">
-                                        <Border Background="{TemplateBinding Background}" CornerRadius="0,0,2,2"
-                                                BorderThickness="1" BorderBrush="{DynamicResource MaterialDesignDivider}"
-                                                SnapsToDevicePixels="True"
-                                                HorizontalAlignment="Stretch">
-                                            <!-- Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpfLib:ShadowAssist.ShadowDepth), Converter={x:Static convertersLib:ShadowConverter.Instance}}" -->
-                                            <ItemsControl x:Name="searchSuggestionsItemsControl" IsEnabled="{TemplateBinding IsEnabled}"
-                                                          Margin="0,4,0,4"
-                                                          HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-                                                          VirtualizingStackPanel.IsVirtualizing="True"
-                                                          ScrollViewer.CanContentScroll="True"
-                                                          ScrollViewer.HorizontalScrollBarVisibility="Disabled" ScrollViewer.VerticalScrollBarVisibility="Auto">
+                                        <Border
+                                            HorizontalAlignment="Stretch"
+                                            Background="{TemplateBinding Background}"
+                                            BorderBrush="{DynamicResource MaterialDesignDivider}"
+                                            BorderThickness="1"
+                                            CornerRadius="0,0,2,2"
+                                            SnapsToDevicePixels="True">
+                                            <!--  Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpfLib:ShadowAssist.ShadowDepth), Converter={x:Static convertersLib:ShadowConverter.Instance}}"  -->
+                                            <ItemsControl
+                                                x:Name="searchSuggestionsItemsControl"
+                                                Margin="0,4,0,4"
+                                                HorizontalAlignment="Stretch"
+                                                VerticalAlignment="Stretch"
+                                                FontSize="{TemplateBinding FontSize}"
+                                                IsEnabled="{TemplateBinding IsEnabled}"
+                                                ScrollViewer.CanContentScroll="True"
+                                                ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                                                ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                                VirtualizingStackPanel.IsVirtualizing="True">
                                                 <ItemsControl.Template>
                                                     <ControlTemplate TargetType="{x:Type ItemsControl}">
                                                         <Border SnapsToDevicePixels="True">
@@ -140,9 +210,14 @@
                                                 </ItemsControl.ItemsPanel>
                                                 <ItemsControl.ItemTemplate>
                                                     <DataTemplate>
-                                                        <Grid Background="Transparent" HorizontalAlignment="Stretch" Height="56">
-                                                            <Border Background="{Binding Path=Foreground, Converter={StaticResource brushRoundConverter}, ElementName=itemButton}"
-                                                                    HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                                                        <Grid
+                                                            Height="56"
+                                                            HorizontalAlignment="Stretch"
+                                                            Background="Transparent">
+                                                            <Border
+                                                                HorizontalAlignment="Stretch"
+                                                                VerticalAlignment="Stretch"
+                                                                Background="{Binding Path=Foreground, Converter={StaticResource brushRoundConverter}, ElementName=itemButton}">
                                                                 <Border.Style>
                                                                     <Style TargetType="{x:Type Border}">
                                                                         <Style.Triggers>
@@ -168,8 +243,10 @@
                                                                     </Style>
                                                                 </Border.Style>
                                                             </Border>
-                                                            <Button x:Name="itemButton" Command="{x:Static internalCommands:SearchControlCommands.SelectSearchSuggestionCommand}"
-                                                                    CommandParameter="{Binding Path=Suggestion}">
+                                                            <Button
+                                                                x:Name="itemButton"
+                                                                Command="{x:Static internalCommands:SearchControlCommands.SelectSearchSuggestionCommand}"
+                                                                CommandParameter="{Binding Path=Suggestion}">
                                                                 <Button.Style>
                                                                     <Style TargetType="{x:Type Button}">
                                                                         <Setter Property="Background" Value="Transparent" />
@@ -186,25 +263,33 @@
                                                                         <Setter Property="Template">
                                                                             <Setter.Value>
                                                                                 <ControlTemplate TargetType="Button">
-                                                                                    <wpfLib:Ripple Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}"
-                                                                                                   Focusable="False"
-                                                                                                   HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                                                                   VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                                                                   Padding="{TemplateBinding Padding}"
-                                                                                                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                                                                    <wpfLib:Ripple
+                                                                                        Padding="{TemplateBinding Padding}"
+                                                                                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                                                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                                                        Content="{TemplateBinding Content}"
+                                                                                        ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                                                        Focusable="False"
+                                                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                                                                                 </ControlTemplate>
                                                                             </Setter.Value>
                                                                         </Setter>
                                                                     </Style>
                                                                 </Button.Style>
                                                                 <DockPanel>
-                                                                    <wpfLib:PackIcon Kind="Clock" Height="24" Width="24"
-                                                                                     Foreground="{DynamicResource MaterialDesignDivider}"
-                                                                                     VerticalAlignment="Center"
-                                                                                     Visibility="{Binding Path=IsFromHistory, Converter={StaticResource falseToHiddenConverter}}" />
-                                                                    <TextBlock Text="{Binding Path=Suggestion}" TextTrimming="CharacterEllipsis"
-                                                                               FontSize="16"
-                                                                               Margin="24,0,0,0" HorizontalAlignment="Stretch" VerticalAlignment="Center" />
+                                                                    <wpfLib:PackIcon
+                                                                        Width="24"
+                                                                        Height="24"
+                                                                        VerticalAlignment="Center"
+                                                                        Foreground="{DynamicResource MaterialDesignDivider}"
+                                                                        Kind="Clock"
+                                                                        Visibility="{Binding Path=IsFromHistory, Converter={StaticResource falseToHiddenConverter}}" />
+                                                                    <TextBlock
+                                                                        Margin="24,0,0,0"
+                                                                        HorizontalAlignment="Stretch"
+                                                                        VerticalAlignment="Center"
+                                                                        Text="{Binding Path=Suggestion}"
+                                                                        TextTrimming="CharacterEllipsis" />
                                                                 </DockPanel>
                                                             </Button>
                                                         </Grid>
@@ -221,5 +306,15 @@
             </Setter.Value>
         </Setter>
     </Style>
-    
+
+    <Style
+        x:Key="MaterialDesignPersistentSearchDense"
+        BasedOn="{StaticResource MaterialDesignPersistentSearch}"
+        TargetType="{x:Type controls:PersistentSearch}">
+        <Setter Property="FontSize" Value="12" />
+        <Setter Property="Padding" Value="8,2,0,2" />
+    </Style>
+
+    <Style BasedOn="{StaticResource MaterialDesignPersistentSearch}" TargetType="{x:Type controls:PersistentSearch}" />
+
 </ResourceDictionary>


### PR DESCRIPTION
I've added a MaterialDesignPersistentSearchDense style to SearchTemplates.xaml. I've also gave the original PersistentSearch style the name MaterialDesignPersistentSearch and set it as default. One thing I wasn't able to do is have the icons a different size in the MaterialDesignPersistentSearchDense style.