### PR TITLE
Fixed? issue with accessing VolumeLabel property for …

### DIFF
--- a/MaterialDesignExtensions/Controllers/FileSystemController.cs
+++ b/MaterialDesignExtensions/Controllers/FileSystemController.cs
@@ -208,7 +208,15 @@ namespace MaterialDesignExtensions.Controllers
                             label = label.Substring(0, label.Length - 1);
                         }
 
-                        string volumeLabel = driveInfo.IsReady ? driveInfo.VolumeLabel : null;
+                        string volumeLabel = null;
+                        try
+                        {
+                            volumeLabel = driveInfo.IsReady ? driveInfo.VolumeLabel : null;
+                        }
+                        catch (IOException exception) when (exception.Message.StartsWith("An unexpected network error occurred"))
+                        {
+                            return new SpecialDrive { Info = driveInfo, Icon = icon };
+                        }
 
                         if (string.IsNullOrWhiteSpace(volumeLabel) && driveInfo.DriveType == DriveType.Fixed)
                         {
@@ -610,7 +618,7 @@ namespace MaterialDesignExtensions.Controllers
                     currentDirectoryPathParts.Add(directoryInfo);
                     directoryInfo = directoryInfo.Parent;
                 }
-                
+
                 currentDirectoryPathParts.Sort((directoryInfo1, directoryInfo2) => directoryInfo1.FullName.CompareTo(directoryInfo2.FullName));
             }
 
@@ -695,7 +703,7 @@ namespace MaterialDesignExtensions.Controllers
             {
                 throw new ArgumentException(string.Format(Localization.Strings.TheDirectoryXAlreadyExists, newDirectoryName));
             }
-            
+
             // create directory and select it
             newDirectory.Create();
 

--- a/MaterialDesignExtensions/Controllers/FileSystemController.cs
+++ b/MaterialDesignExtensions/Controllers/FileSystemController.cs
@@ -213,7 +213,7 @@ namespace MaterialDesignExtensions.Controllers
                         {
                             volumeLabel = driveInfo.IsReady ? driveInfo.VolumeLabel : null;
                         }
-                        catch (IOException exception) when (exception.Message.StartsWith("An unexpected network error occurred"))
+                        catch (Exception exception)
                         {
                             return new SpecialDrive { Info = driveInfo, Icon = icon };
                         }


### PR DESCRIPTION
... Network drives that can't be accessed.
I have a network drive that i can't access. Accessing the property, VolumeLabel, caused an IOException. 
This is my fix. 