### PR TITLE
Add new properties to TabControlAssist

### DIFF
--- a/MaterialDesignExtensions/Controls/TabControlAssist.cs
+++ b/MaterialDesignExtensions/Controls/TabControlAssist.cs
@@ -192,5 +192,96 @@ namespace MaterialDesignExtensions.Controls
         {
             element.SetValue(TabHeaderForegroundProperty, value);
         }
+
+        /// <summary>
+        /// The current font size of the tab item header. Intended to be read-only.
+        /// </summary>
+        public static readonly DependencyProperty TabHeaderFontSizeProperty = DependencyProperty.RegisterAttached(
+            "TabHeaderFontSize",
+            typeof(double),
+            typeof(TabControlAssist),
+            new FrameworkPropertyMetadata(14.0, FrameworkPropertyMetadataOptions.Inherits, null)
+        );
+
+        /// <summary>
+        /// Gets the current font size of the tab item header.
+        /// </summary>
+        /// <param name="element"></param>
+        /// <returns></returns>
+        public static double GetTabHeaderFontSize(DependencyObject element)
+        {
+            return (double)element.GetValue(TabHeaderFontSizeProperty);
+        }
+
+        /// <summary>
+        /// Sets the current font size of the tab item header.
+        /// </summary>
+        /// <param name="element"></param>
+        /// <param name="value"></param>
+        public static void SetTabHeaderFontSize(DependencyObject element, double value)
+        {
+            element.SetValue(TabHeaderFontSizeProperty, value);
+        }
+
+        /// <summary>
+        /// The current font weight of the tab item header. Intended to be read-only.
+        /// </summary>
+        public static readonly DependencyProperty TabHeaderFontWeightProperty = DependencyProperty.RegisterAttached(
+            "TabHeaderFontWeight",
+            typeof(FontWeight),
+            typeof(TabControlAssist),
+            new FrameworkPropertyMetadata(FontWeights.Medium, FrameworkPropertyMetadataOptions.Inherits, null)
+        );
+
+        /// <summary>
+        /// Gets the current font weight of the tab item header.
+        /// </summary>
+        /// <param name="element"></param>
+        /// <returns></returns>
+        public static FontWeight GetTabHeaderFontWeight(DependencyObject element)
+        {
+            return (FontWeight)element.GetValue(TabHeaderFontWeightProperty);
+        }
+
+        /// <summary>
+        /// Sets the current font weight of the tab item header.
+        /// </summary>
+        /// <param name="element"></param>
+        /// <param name="value"></param>
+        public static void SetTabHeaderFontWeight(DependencyObject element, FontWeight value)
+        {
+            element.SetValue(TabHeaderFontWeightProperty, value);
+        }
+
+
+        /// <summary>
+        /// The current margin of the tab item header's content. Intended to be read-only.
+        /// </summary>
+        public static readonly DependencyProperty TabHeaderMarginProperty = DependencyProperty.RegisterAttached(
+            "TabHeaderMargin",
+            typeof(Thickness),
+            typeof(TabControlAssist),
+            new FrameworkPropertyMetadata(new Thickness(24,12,24,12), FrameworkPropertyMetadataOptions.Inherits, null)
+        );
+
+        /// <summary>
+        /// Gets the current margin of the tab item header's content.
+        /// </summary>
+        /// <param name="element"></param>
+        /// <returns></returns>
+        public static Thickness GetTabHeaderMargin(DependencyObject element)
+        {
+            return (Thickness)element.GetValue(TabHeaderMarginProperty);
+        }
+
+        /// <summary>
+        /// Sets the current margin of the tab item header's content.
+        /// </summary>
+        /// <param name="element"></param>
+        /// <param name="value"></param>
+        public static void SetTabHeaderMargin(DependencyObject element, Thickness value)
+        {
+            element.SetValue(TabHeaderMarginProperty, value);
+        }
     }
 }

--- a/MaterialDesignExtensions/Themes/TabControlTemplates.xaml
+++ b/MaterialDesignExtensions/Themes/TabControlTemplates.xaml
@@ -75,8 +75,10 @@
                                                 </Border.RenderTransform>
                                             </Border>
                                             <ContentPresenter x:Name="headerContent" ContentSource="Header" RecognizesAccessKey="True"
-                                                              Margin="24,12,24,12" HorizontalAlignment="Center" VerticalAlignment="Center"
-                                                              TextBlock.FontSize="14" TextBlock.FontWeight="Medium"
+                                                              HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                              Margin="{Binding Path=(controls:TabControlAssist.TabHeaderMargin), RelativeSource={RelativeSource TemplatedParent}}" 
+                                                              TextBlock.FontSize="{Binding Path=(controls:TabControlAssist.TabHeaderFontSize), RelativeSource={RelativeSource TemplatedParent}}" 
+                                                              TextBlock.FontWeight="{Binding Path=(controls:TabControlAssist.TabHeaderFontWeight), RelativeSource={RelativeSource TemplatedParent}}"
                                                               TextBlock.Foreground="{Binding Path=(controls:TabControlAssist.TabHeaderForeground), RelativeSource={RelativeSource TemplatedParent}}">
                                                 <ContentPresenter.Style>
                                                     <Style TargetType="ContentPresenter">


### PR DESCRIPTION
Related to #126 . 
Added following properties to the `TabControlAssist` class:

- `TabHeaderFontSize`
- `TabHeaderFontWeight`
- `TabHeaderMargin`

`TabHeaderFontSize` and `TabHeaderFontWeight` are bind to the `TextBlock` properties inside of  `ContentPresenter`.
`TabHeaderMargin` is bind to `ContentPresenter`'s margin.
