### PR TITLE
Update ResourceDictionaryExtensions.cs

### DIFF
--- a/MaterialDesignExtensions/Themes/ResourceDictionaryExtensions.cs
+++ b/MaterialDesignExtensions/Themes/ResourceDictionaryExtensions.cs
@@ -31,8 +31,6 @@ namespace MaterialDesignExtensions.Themes
 
         private static object ReadKey(string keyName)
         {
-            var type = typeof(MaterialDesignThemes.Wpf.ResourceDictionaryExtensions);
-            
             // Read as constant field for 4.0.0
             var fieldInfo = type.GetField(keyName, BindingFlags.Static | BindingFlags.NonPublic);
             if (fieldInfo != null)

--- a/MaterialDesignExtensions/Themes/ResourceDictionaryExtensions.cs
+++ b/MaterialDesignExtensions/Themes/ResourceDictionaryExtensions.cs
@@ -31,6 +31,8 @@ namespace MaterialDesignExtensions.Themes
 
         private static object ReadKey(string keyName)
         {
+            var type = typeof(MaterialDesignThemes.Wpf.ResourceDictionaryExtensions);
+            
             // Read as constant field for 4.0.0
             var fieldInfo = type.GetField(keyName, BindingFlags.Static | BindingFlags.NonPublic);
             if (fieldInfo != null)


### PR DESCRIPTION
Fixes #134 

### Issue:
When using MaterialDesignThemes.WPF.4.0.0 Creating an instance of "MaterialDesignExtensions.Themes.PaletteHelper" fails with NullReferenceException.

at MaterialDesignExtensions.Themes.ResourceDictionaryExtensions.GetExtendedTheme(ResourceDictionary resourceDictionary) at MaterialDesignExtensions.Themes.PaletteHelper.GetExtendedTheme() at UxControls.Themes.ThemeHelper.ModifyTheme(Action1 modificationAction) in C:\DDrive\Temp\ShellApp\UxControls\Themes\ThemeHelper.cs:line 41
at UxControls.Themes.ThemeHelper.SetTheme(ColorTheme colors) in C:\DDrive\Temp\ShellApp\UxControls\Themes\ThemeHelper.cs:line 12
at T1ShellApp.MainWindow..ctor() in C:\DDrive\Temp\ShellApp\T1ShellApp\MainWindow.xaml.cs:line 33`

### Root Cause:
This is caused due to the fact MaterialDesignThemes.Wpf.ResourceDictionaryExtensions in 4.0.0 has changed the properties CurrentThemeKey and ThemeManagerKey to a constant. Also changed their types from GUID to string. This causes MaterialDesignExtensions.Themes.ResourceDictionaryExtensions type initializer to throw up as it Reflects on these items as properties.

### Proposed Fix:
Update the MaterialDesignExtensions.Themes.ResourceDictionaryExtensions type initializer to use CurrentThemeKey and ThemeManagerKey as Fields and not properties. To support 3.2.0 fallback to Property read if field is not available.

Also since CurrentThemeKey and ThemeManagerKey are just used as lookup into ResourceDictionary leave them as Object type so it can support both 3.2.0 (Guid) and 4.0.0 (String) of MaterialDesignThemes.Wpf.ResourceDictionaryExtensions class.